### PR TITLE
doc(plugins/http-services): link to DI. Closes #477

### DIFF
--- a/current/en-us/7. plugins/1. http-services.md
+++ b/current/en-us/7. plugins/1. http-services.md
@@ -54,7 +54,7 @@ export function configure(aurelia: Aurelia): void {
 ```
 
 > Info: Encapsulate HttpClient Use
-> Generally, we recommend that you don't litter your application code with usage of the HttpClient. Instead, we reccommend that you create one or more service classes that encapsulate all HTTP access behind a friendly, application-specific API. If you do this, we also recommend that you import the `fetch` polyfill inside these service modules rather than in your application's main module. This helps to preserve the encapsulation.
+> Generally, we recommend that you don't litter your application code with usage of the HttpClient. Instead, we reccommend that you [create one or more service classes that encapsulate all HTTP access](docs/fundamentals/dependency-injection#injection) behind a friendly, application-specific API. If you do this, we also recommend that you import the `fetch` polyfill inside these service modules rather than in your application's main module. This helps to preserve the encapsulation.
 
 ### Basic Use
 


### PR DESCRIPTION
It doesn't fit optimal, but when I first read the docs regarding HttpClient, I wondered _how_ to wrap the client in a custom service.
This way, there's at least a starting point.